### PR TITLE
As of PHP 5.4.0, call-time pass-by-reference was removed, so using it wi...

### DIFF
--- a/app/code/community/Mns/Resque/Model/Runner.php
+++ b/app/code/community/Mns/Resque/Model/Runner.php
@@ -52,7 +52,7 @@ class Mns_Resque_Model_Runner extends Mage_Core_Model_Abstract
         $return = null;
         $command = $this->buildStartShellCommand($this->getConfig(), $this->getLogLevel(), $this->getQueue());
         $this->disableOwnSignalHandlers();
-        system($command, &$return);
+        system($command, $return);
 
         return $return;
     }
@@ -66,7 +66,7 @@ class Mns_Resque_Model_Runner extends Mage_Core_Model_Abstract
     {
         $return = null;
         $command = $this->buildStopShellCommand();
-        system($command, &$return);
+        system($command, $return);
 
         if ($return === 0) {
             unlink($this->buildPidfilePath());


### PR DESCRIPTION
...ll raise a fatal error. http://php.net/manual/en/language.references.pass.php
