### PR TITLE
Allow to have bin directory elsewhere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ PHP Resque is a Redis backed job queue, and you will need access to a running Re
 
 If you use Redis for Magento caching or as a session store, e.g. you use [one of](https://github.com/colinmollenhour/Cm_Cache_Backend_Redis) [Colin Mollenhour's](https://twitter.com/colinmollenhour) [excellent modules](https://github.com/colinmollenhour/Cm_RedisSession), then make sure you select an alternate database, or better yet, a separate Redis instance that is exclusively for Mage Resque.
 
+If you are storing your binaries in a different directory, you can specify it in local.xml as well:
+
+    <default>
+        <mnsresque>
+           ...
+           <env>
+             <bin_dir>bin</bin_dir>
+           </env>
+        </mnsresque>
+    </default>
+
 ### Usage
 PHP Resque has two functions, to add jobs to Redis backed job queues, and to manage workers processing jobs from those queues.
 

--- a/app/code/community/Mns/Resque/Model/Config.php
+++ b/app/code/community/Mns/Resque/Model/Config.php
@@ -17,4 +17,12 @@ class Mns_Resque_Model_Config extends Mage_Core_Model_Abstract
     {
         return Mage::getStoreConfig('mnsresque/redis/database');
     }
+
+    /**
+     * @return string
+     */
+    public function getBinDir()
+    {
+        return Mage::getStoreConfig('mnsresque/env/bin_dir');
+    }
 }

--- a/app/code/community/Mns/Resque/Model/Runner.php
+++ b/app/code/community/Mns/Resque/Model/Runner.php
@@ -133,7 +133,7 @@ class Mns_Resque_Model_Runner extends Mage_Core_Model_Abstract
             $config->getDatabase(),
             $this->getQueueEnv($queue),
             $this->getLogEnv($logLevel),
-            Mage::getBaseDir() . DS . 'shell' . DS . 'resque',
+            Mage::getBaseDir() . DS . $config->getBinDir() . DS . 'resque',
             $this->buildLogfilePath());
     }
 

--- a/app/code/community/Mns/Resque/etc/config.xml
+++ b/app/code/community/Mns/Resque/etc/config.xml
@@ -26,6 +26,9 @@
                 <backend>localhost:6379</backend>
                 <database>4</database>
             </redis>
+            <env>
+                <bin_dir>shell</bin_dir>
+            </env>
         </mnsresque>
     </default>
 </config>


### PR DESCRIPTION
We don't have our binaries in `shell`, which is hardcoded as of now. This pull request makes it configurable, but assumes `shell` as default.
